### PR TITLE
Changed module import to support azure func v4

### DIFF
--- a/VINResolver/__init__.py
+++ b/VINResolver/__init__.py
@@ -14,16 +14,9 @@ for handler in logger.handlers:
         handler.setFormatter(formatter)
 
 # Import custom modules
-try:
-    from  __app__.modules.libvin import Vin
-    from  __app__.modules import luis_helper
-    from  __app__.modules import resolve_spelling as resolve
-    logger.info("[INFO] Helper: Using app imports.")
-except Exception as e:
-    logger.info("[INFO] Helper: Using local imports.")
-    from  modules.libvin import Vin
-    from  modules import luis_helper
-    from  modules import resolve_spelling as resolve
+from modules.libvin import Vin
+from modules import luis_helper
+from modules import resolve_spelling as resolve
 
 def clean(phrase, lang='de'):
     """Cleaning steps for extracted phrase, with area detection in between"""


### PR DESCRIPTION
Within azure functions v4, it is no longer possible to import modules via `__app__` (apparently a quite old way of importing it, from version ) - therefore, i'd recommend to change it.

This also affects the `host.json` in the root directory, which is the global definition of the functions version.